### PR TITLE
Adopt new asset catalogue folder structure

### DIFF
--- a/Sources/Catalogue/main.swift
+++ b/Sources/Catalogue/main.swift
@@ -14,7 +14,7 @@ do {
         let data = try Data(contentsOf: sourceDataPath)
         let decoder = JSONDecoder()
         let colors = try decoder.decode([Color].self, from: data)
-        let creator = AssetCreator(assetFileName: "Primer")
+        let creator = AssetCreator(assetFileName: "Assets")
         try creator.write(colors, at: outputPath)
     }
 } catch {

--- a/Sources/CatalogueKit/AssetCreator.swift
+++ b/Sources/CatalogueKit/AssetCreator.swift
@@ -18,12 +18,17 @@ public struct AssetCreator {
     }()
 
     public func write(_ colors: [Color], at path: String) throws {
-        // Ensure a full-rewrite of assets if one currently exists.
-        let folder = try Folder(path: path + "/\(assetFileName).xcassets", using: fileManager)
-        try folder.delete()
-
+        let rootFolder = 
+            try Folder(path: path + "/\(assetFileName).xcassets", using: fileManager)
+        
+        // Ensure a full-rewrite of Primer assets if one currently exists.
+        let primerFolderName = "Primer"
+        let primerFolder = 
+            try Folder(path: rootFolder.path + "/\(primerFolderName)", using: fileManager) 
+        try primerFolder.delete()
+        
         // Overwrite with a new blank directory.
-        let assetFolder = try fileSystem.createFolderIfNeeded(at: folder.path)
+        let assetFolder = try fileSystem.createFolderIfNeeded(at: rootFolder.path)
         let rootContents = try JSONSerialization.data(withJSONObject: [
             "info" : [
               "version" : 1,
@@ -32,7 +37,8 @@ public struct AssetCreator {
         ], options: [.prettyPrinted])
         try assetFolder.createFile(named: "Contents.json", contents: rootContents)
 
-        let colorsFolder = try assetFolder.createSubfolder(named: "Colors")
+        let colorsFolder = 
+            try assetFolder.createSubfolder(named: primerFolderName)
 
         try colors.forEach { color in
             let currentColorFolder = try colorsFolder.createSubfolder(named: color.name + ".colorset")


### PR DESCRIPTION
We had `Primer.xcassets` for the colors in the past, but now we have `Assets.xcassets` for diverse asset types, and the color is now living under `Assets.xcassets/Primer/`. This PR makes the code adopts the new folder structure. The command stays the same.